### PR TITLE
 [bug fix]: local variable 'term' referenced before assignment

### DIFF
--- a/lib2pass/main.py
+++ b/lib2pass/main.py
@@ -255,7 +255,7 @@ def merge(bed_fns, output_bed_fn, ref_fasta_fn, annot_bed_fn,
     ))
     log.info(f'Writing results to {output_bed_fn}')
     with open(output_bed_fn, 'w') as bed:
-        for i, motif, c, jad, pd, pa, d1, lrd, lra, d2 in res:
+        for i, motif,_, c, jad, pd, pa, d1, lrd, lra, d2 in res:
             chrom, start, end, strand = i
             bed.write(
                 f'{chrom:s}\t{start:d}\t{end:d}\t{motif:s}\t{c:d}\t{strand:s}\t'

--- a/lib2pass/merge.py
+++ b/lib2pass/merge.py
@@ -15,7 +15,7 @@ def read_junc_bed(bed_fn):
             ln = end - start
             count = int(count)
             jad = int(jad)
-            term = int(term)
+#             term = int(term)
             i = (chrom, start, end, strand)
             motifs[i] = motif
             lengths[i] = ln


### PR DESCRIPTION
fix two issue:

- `too many values to unpack (expected 10)` in the main.py
- `local variable 'term' referenced before assignment` in the merge.py